### PR TITLE
Allow to instantiate `InventoryItem` on 32bit system

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,9 +26,15 @@ jobs:
           - title: 'Linux - Latest'
             os: ubuntu-latest
             version: '1'
+            arch: x64
           - title: 'Windows - Latest'
             os: windows-latest
             version: '1'
+            arch: x64
+          - title: 'Linux - 32bit'
+            os: ubuntu-latest
+            version: '1'
+            arch: x86
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocInventories"
 uuid = "43dc2714-ed3b-44b5-b226-857eda1aa7de"
 authors = ["Michael Goerz <mail@michaelgoerz.net>"]
-version = "0.3.0"
+version = "0.3.0+dev"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/inventory_item.jl
+++ b/src/inventory_item.jl
@@ -97,7 +97,7 @@ struct InventoryItem
     name::String
     domain::String
     role::String
-    priority::Int64
+    priority::Int
     uri::String
     dispname::String
 
@@ -105,7 +105,7 @@ struct InventoryItem
         name::AbstractString,
         domain::AbstractString,
         role::AbstractString,
-        priority::Int64,
+        priority::Int,
         uri::AbstractString,
         dispname::AbstractString
     )


### PR DESCRIPTION
The `priority` field should be whatever the default `Int` type is, not `Int64` specifically.