### PR TITLE
Allow to instantiate `InventoryItem` with `priority` of any Integer type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocInventories"
 uuid = "43dc2714-ed3b-44b5-b226-857eda1aa7de"
 authors = ["Michael Goerz <mail@michaelgoerz.net>"]
-version = "0.3.1"
+version = "0.3.1+dev"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/inventory.jl
+++ b/src/inventory.jl
@@ -146,7 +146,7 @@ end
 Base.length(inventory::Inventory) = length(inventory._items)
 Base.iterate(inventory::Inventory) = iterate(inventory._items)
 Base.iterate(inventory::Inventory, state) = iterate(inventory._items, state)
-Base.getindex(inventory::Inventory, ind::Int64) = getindex(inventory._items, ind)
+Base.getindex(inventory::Inventory, ind::Int) = getindex(inventory._items, ind)
 Base.firstindex(inventory::Inventory) = firstindex(inventory._items)
 Base.lastindex(inventory::Inventory) = lastindex(inventory._items)
 Base.eltype(::Inventory) = InventoryItem

--- a/src/inventory_item.jl
+++ b/src/inventory_item.jl
@@ -105,7 +105,7 @@ struct InventoryItem
         name::AbstractString,
         domain::AbstractString,
         role::AbstractString,
-        priority::Int,
+        priority::Integer,
         uri::AbstractString,
         dispname::AbstractString
     )

--- a/src/sphinx_format.jl
+++ b/src/sphinx_format.jl
@@ -150,7 +150,7 @@ function read_inventory(
                     name=m["name"],
                     domain=m["domain"],
                     role=m["role"],
-                    priority=parse(Int64, m["priority"]),
+                    priority=parse(Int, m["priority"]),
                     uri=m["uri"],
                     dispname=m["dispname"],
                 )

--- a/test/test_inventory_item.jl
+++ b/test/test_inventory_item.jl
@@ -90,6 +90,20 @@ using IOCapture: IOCapture
 end
 
 
+@testset "IventoryItem on 32-bit" begin
+    item = InventoryItem("f" => "#f"; priority=Int32(1))
+    @test item.priority == 1
+    item = InventoryItem("f" => "#f"; priority=Int64(1))
+    @test item.priority == 1
+    item = InventoryItem("f" => "#f"; priority=UInt8(1))
+    @test item.priority == 1
+    item = InventoryItem("f" => "#f"; priority=Int8(1))
+    @test item.priority == 1
+    item = InventoryItem("f" => "#f"; priority=1)
+    @test item.priority == 1
+end
+
+
 @testset "invalid IventoryItem" begin
     @test_throws ArgumentError begin
         InventoryItem(


### PR DESCRIPTION
This is a further fix to ensure DocInventories runs well on 32-bit systems.