### PR TITLE
Revise `Inventory` equality

### DIFF
--- a/src/inventory.jl
+++ b/src/inventory.jl
@@ -38,11 +38,13 @@ added afterwards via [`push!`](@extref Julia Base.push!).
 * `root_url`: The root URL to which the `item.uri` of any
   [`InventoryItem`](@ref) is relative. If not empty, should start with
   `"https://"` and end with a slash.
-* `source`: The URL or filename from which the inventory was loaded, or a
-   comment if the inventory was constructed otherwise.
+* `source`: The URL or filename from which the inventory was loaded.
 * `sorted`: A boolean to indicate whether the items are sorted by their `name`
    attribute, allowing for efficient lookup. This is `true` for all inventories
    loaded from a URL or file and `false` for manually instantiated inventories.
+
+Note that `source` and `sorted` are informational attributes only and are
+ignored when comparing two `Inventory` objects.
 
 # Item access
 
@@ -160,8 +162,8 @@ function Base.:(==)(l::Inventory, r::Inventory)
     (l.project == r.project) || (return false)
     (l.version == r.version) || (return false)
     (l._items == r._items) || (return false)
-    (l.source == r.source) || (return false)
-    (l.sorted == r.sorted) || (return false)
+    (l.root_url == r.root_url) || (return false)
+    # `source` and `sorted` are deliberately not part of the comparison
     return true
 end
 

--- a/test/test_inventory.jl
+++ b/test/test_inventory.jl
@@ -477,6 +477,68 @@ end
 end
 
 
+@testset "Iventory equality" begin
+    items = [InventoryItem("f" => "f"), InventoryItem("g" => "g"),]
+    inventory1 = Inventory(
+        "ProjectA",
+        "1.0.0",
+        items,
+        "https://github.com/JuliaDocs/DocInventories.jl",
+        "test1",
+        true
+    )
+    @test inventory1 == inventory1
+    inventory2 = Inventory(
+        "ProjectA",
+        "1.0.0",
+        items,
+        "https://github.com/JuliaDocs/DocInventories.jl",
+        "test2",
+        false
+    )
+    @test inventory2 == inventory1
+    inventory3 = Inventory(
+        "ProjectB",
+        "1.0.0",
+        items,
+        "https://github.com/JuliaDocs/DocInventories.jl",
+        "test1",
+        true
+    )
+    @test inventory3 != inventory1
+    inventory4 = Inventory(
+        "ProjectA",
+        "1.0.0+dev",
+        items,
+        "https://github.com/JuliaDocs/DocInventories.jl",
+        "test1",
+        true
+    )
+    @test inventory4 != inventory1
+    items2 = [InventoryItem("g" => "g"), InventoryItem("f" => "f"),]
+    inventory5 = Inventory(
+        "ProjectA",
+        "1.0.0",
+        items2,
+        "https://github.com/JuliaDocs/DocInventories.jl",
+        "test1",
+        false
+    )
+    @test inventory5 != inventory1
+    inventory6 = Inventory(
+        "ProjectA",
+        "1.0.0",
+        items,
+        "https://github.com/JuliaDocs/DocInventories2.jl",
+        "test1",
+        true
+    )
+    @test inventory6 != inventory1
+
+end
+
+
+
 @testset "Search inventory" begin
 
     inventory = Inventory(project="Search", version="1.0")


### PR DESCRIPTION
The `source` and `sorted` attributes do not matter when comparing two `Inventory` objects. This makes it easier to load two inventory files and compare them.

On the other hand, `root_url` does matter, since that changes what e.g. the `uri` function returns.