### PR TITLE
Improve auto-mime filename recognition

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocInventories"
 uuid = "43dc2714-ed3b-44b5-b226-857eda1aa7de"
 authors = ["Michael Goerz <mail@michaelgoerz.net>"]
-version = "0.4.0"
+version = "0.4.0+dev"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/mimetypes.jl
+++ b/src/mimetypes.jl
@@ -29,12 +29,11 @@ const MIME_TYPES = Dict(
 function splitfullext(filepath::String)
     root, ext = splitext(filepath)
     full_ext = ext
-
-    # Keep splitting until no more extensions are found
-    while ext != ""
+    if ext == ".gz"
         root, ext = splitext(root)
-        (ext == "") && break
-        full_ext = ext * full_ext
+        if (ext != "")
+            full_ext = ext * full_ext
+        end
     end
     return root, full_ext
 end

--- a/test/test_inventory.jl
+++ b/test/test_inventory.jl
@@ -1,7 +1,8 @@
 using Test
 using TestingUtilities: @Test
 using DocInventories
-using DocInventories: uri, spec, find_in_inventory, split_url, show_full, set_metadata
+using DocInventories:
+    uri, spec, find_in_inventory, split_url, show_full, set_metadata, auto_mime
 using DocInventories: InventoryFormatError
 using Downloads: RequestError
 using IOCapture: IOCapture
@@ -756,4 +757,23 @@ end
 
     end
 
+end
+
+
+@testset "auto_mime" begin
+    @test auto_mime("objects.inv") == MIME("application/x-intersphinx")
+    @test auto_mime("Julia-1.10.2.inv") == MIME("application/x-intersphinx")
+    @test auto_mime("objects.txt") == MIME("text/x-intersphinx")
+    @test auto_mime("Julia-1.10.2.txt") == MIME("text/x-intersphinx")
+    @test auto_mime("objects.txt.gz") == MIME("text/x-intersphinx+gzip")
+    @test auto_mime("Julia-1.10.2.txt.gz") == MIME("text/x-intersphinx+gzip")
+    @test auto_mime("inventory.toml") == MIME("application/toml")
+    @test auto_mime("Julia-1.10.2.toml") == MIME("application/toml")
+    @test auto_mime("inventory.toml.gz") == MIME("application/toml+gzip")
+    @test auto_mime("Julia-1.10.2.toml.gz") == MIME("application/toml+gzip")
+    captured = IOCapture.capture(rethrow=Union{}) do
+        auto_mime("inventory.toml.zip")
+    end
+    @test captured.value isa ArgumentError
+    @test contains(captured.output, "Cannot determine MIME type")
 end


### PR DESCRIPTION
Fix the MIME identification of file names like "Julia-1.10.2.inv" and "Julia-1.10.2.toml.gz". That is, split file extensions with ".gz" correctly, but don't split off too much.